### PR TITLE
Fixed a few lingering QA issues

### DIFF
--- a/_includes/topbar.html
+++ b/_includes/topbar.html
@@ -6,7 +6,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="index.html"><img src="media/images/esgfSmall.png" style="float:left"></a>
+            <a href="index.html"><img src="media/images/esgfSmall.png" style="float:left" alt="ESGF logo" ></a>
             <div class="nav-collapse">
                 <ul class="nav">
                     <li class="dropdown">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -50,7 +50,7 @@
         <a href="https://aims.llnl.gov/" target="_blank">AIMS</a> &bull;
         <a href="https://llnl.gov/" target="_blank">LLNL</a> &bull;
         <a href="LICENSE.html">License</a> &bull;
-        <a href="https://www.llnl.gov/disclaimer.html" target="_blank">LLNL-WEB-460691</a> &bull;
+        <a href="https://www.llnl.gov/disclaimer" target="_blank">LLNL-WEB-460691</a> &bull;
         <a href="https://github.com/ESGF/esgf.github.io/issues" target="_blank">Site Issues</a> &bull;
         <a href="mailing-list.html">Contact</a>
 

--- a/projects.md
+++ b/projects.md
@@ -63,7 +63,7 @@ administrators.
 
 ### orp
 
-##### [Source][ESGF/esgf-orp], [Issues][ESGF/esgf-orp/issues], [Wiki][ESGF/esgf-orp/wiki]
+##### [Source][ESGF/esg-orp], [Issues][ESGF/esg-orp/issues], [Wiki][ESGF/esg-orp/wiki]
 
 <img src="{{site.url}}/media/images/orp.png" class="project-icon">
 
@@ -90,7 +90,7 @@ across the federation.
 
 ### search
 
-##### [Source][ESGF/esgf-search], [Issues][ESGF/esgf-search/issues], [Wiki][ESGF/esgf-search/wiki]
+##### [Source][ESGF/esg-search], [Issues][ESGF/esg-search/issues], [Wiki][ESGF/esg-search/wiki]
 
 <img src="{{site.url}}/media/images/search.png" class="project-icon">
 
@@ -112,17 +112,17 @@ package contains functionality for:
 [ESGF/esgf-idp/wiki]:             https://github.com/ESGF/esgf-idp/wiki
 
 
-[ESGF/esgf-orp]:                  https://github.com/ESGF/esgf-orp
-[ESGF/esgf-orp/issues]:           https://github.com/ESGF/esgf-orp/issues
-[ESGF/esgf-orp/wiki]:             https://github.com/ESGF/esgf-orp/wiki
+[ESGF/esg-orp]:                  https://github.com/ESGF/esg-orp
+[ESGF/esg-orp/issues]:           https://github.com/ESGF/esg-orp/issues
+[ESGF/esg-orp/wiki]:             https://github.com/ESGF/esg-orp/wiki
 
 [ESGF/esg-publisher]:            https://github.com/ESGF/esg-publisher
 [ESGF/esg-publisher/issues]:     https://github.com/ESGF/esg-publisher/issues
 [ESGF/esg-publisher/wiki]:       https://github.com/ESGF/esg-publisher/wiki
 
-[ESGF/esgf-search]:               https://github.com/ESGF/esgf-search
-[ESGF/esgf-search/issues]:        https://github.com/ESGF/esgf-search/issues
-[ESGF/esgf-search/wiki]:          https://github.com/ESGF/esgf-search/wiki
+[ESGF/esg-search]:               https://github.com/ESGF/esg-search
+[ESGF/esg-search/issues]:        https://github.com/ESGF/esg-search/issues
+[ESGF/esg-search/wiki]:          https://github.com/ESGF/esg-search/wiki
 
 [ESGF/esgf-security]:             https://github.com/ESGF/esgf-security
 [ESGF/esgf-security/issues]:      https://github.com/ESGF/esgf-security/issues

--- a/release1.6.md
+++ b/release1.6.md
@@ -75,7 +75,7 @@ The best and recommended way to install and setup the Node is to first visit the
     </td>
   </tr>
   <tr bgcolor="#eaeaea"><td> java </td><td> v1.7.0_21 </td><td>  <a href="http://www.oracle.com/technetwork/java/index.html" target="rel">http://www.oracle.com/technetwork/java/index.html</a> </td></tr>
-  <tr bgcolor="#ffffff"><td> thredds* </td><td> v4.3.17 </td><td>   <a href="http://www.unidata.ucar.edu/projects/THREDDS/tech/TDS.html" target="rel">http://www.unidata.ucar.edu/projects/THREDDS/tech/TDS.html</a> </td></tr>
+  <tr bgcolor="#ffffff"><td> thredds* </td><td> v4.3.17 </td><td>   http://www.unidata.ucar.edu/projects/THREDDS/tech/TDS.html</td></tr>
   <tr bgcolor="#eaeaea"><td> tomcat </td><td> v7.0.47 </td><td>  <a href="http://tomcat.apache.org/" target="rel">http://tomcat.apache.org/</a> </td></tr>
   <tr bgcolor="#ffffff">
     <td> myproxy* </td><td> v5.0.4 </td><td>http://dev.globus.org/wiki/MyProxy <br>


### PR DESCRIPTION
Lab's main website recently changed its legal/privacy link w/o redirect, which broke it in ESGF's global footer. Fixed incorrect links to esg-orp and esg-search repos and unlinked another broken link on release1.6.md. Also added alt text to the ESGF logo in top menu.