### PR TITLE
ESGF Conference Announcements

### DIFF
--- a/2019-Future-Arch-Workshop.md
+++ b/2019-Future-Arch-Workshop.md
@@ -33,7 +33,7 @@ The programme for the meeting has been specified by Philip Kershaw (UKRI STFC, l
 - Compute on data
 - Platforms, system administration
 
-The meeting aims to agree on a roadmap for future architecture directions in ESGF. The meeting results will be presented and discussed at the upcoming ESGF Face-to Face Conference in March 2020 in Toulouse.
+The meeting aims to agree on a roadmap for future architecture directions in ESGF. The meeting results will be presented and discussed at the upcoming ESGF Face-to-Face Conference in March 2020 in Toulouse.
 
 #### Sponsorship
 

--- a/2019-Future-Arch-Workshop.md
+++ b/2019-Future-Arch-Workshop.md
@@ -1,0 +1,90 @@
+---
+layout: default
+title: ESGF Future Architecture Workshop
+---
+
+<style type="text/css">
+    img {
+        max-height: 180px;
+    }
+
+    div.span12 {
+        margin-bottom: 30px;
+    }
+
+</style>
+
+## ESGF Future Architecture Workshop
+
+ESGF Future Architecture Meeting is a project meeting to review the existing system architecture, examine requirements for a future system and propose new solutions.
+
+#### About this Event
+
+It is now nearly ten years since the original ESGF system was designed. At that time the development was driven by the need to create a globally distributed archive for downloading CMIP data. Since that time, there have been a number of changes: ESGF has grown and diversified in the number of projects and disciplines it supports; the operational requirements are clearer for the ESGF to support an international federated archive of this size; many of the ESGF nodes now have other functions beyond CMIP and there has also been changing landscape of data repository and science needs. This meeting has been convened by the ESGF Executive Committee (ESGF-XC) with the purpose of re-assessing the requirements and developing a future architecture for the system.
+
+#### Meeting Structure
+
+The meeting will run over three days. Attendance is by invitation only and concentrates on ESGF key developers.
+
+The programme for the meeting has been specified by Philip Kershaw (UKRI STFC, local host), Ghaleb Abdullah (LLNL) and Ben Evans (NCI) on behalf of the ESGF-XC. In addition to requirements analysis, technology survey and review high-level architecture the programme concentrates on the topical areas:
+
+- User experience
+- Data repository and management
+- Compute on data
+- Platforms, system administration
+
+The meeting aims to agree on a roadmap for future architecture directions in ESGF. The meeting results will be presented and discussed at the upcoming ESGF Face-to Face Conference in March 2020 in Toulouse.
+
+#### Sponsorship
+
+This workshop is sponsored by IS-ENES3, which has received funding from the European Union’s Horizon 2020 research and innovation programme under grant agreement No 824084, and co-organised by the ESGF-XC and IS-ENES.
+
+ESGF as the global climate data infrastructure is supported by:
+
+<h3> U.S. Sponsors</h3>
+<div class="span12">
+    <div class="row">
+        <div class="span3">
+            <a target="_blank" href="https://www.energy.gov/">
+                <h4 class="muted">DOE</h4>
+                <img src="media/images/doe.svg" class="thumbnail">
+            </a>
+        </div>
+        <div class="span3">
+            <a target="_blank" href="http://www.nasa.gov">
+                <h4 class="muted">NASA</h4>
+                <img src="media/images/nasa.svg" class="thumbnail nasa">
+            </a>
+        </div>
+        <div class="span3">
+            <a target="_blank" href="http://www.noaa.gov">
+                <h4 class="muted">NOAA</h4>
+                <img src="media/images/noaa.svg" class="thumbnail">
+            </a>
+        </div>
+        <div class="span3">
+            <a target="_blank" href="http://www.nsf.gov">
+                <h4 class="muted">NSF</h4>
+                <img src="media/images/nsf.png" class="thumbnail">
+            </a>
+        </div>
+    </div>
+</div>
+
+<h3>European Sponsors &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Australian Sponsors</h3>
+<div class="span12">
+    <div class="row">
+        <div class="span3">
+            <a target="_blank" href="http://enes.org">
+                <h4 class="muted">IS-ENES</h4>
+                <img src="media/images/IS-ENES2.png" class="thumbnail">
+            </a>
+        </div>
+        <div class="span3">
+            <a target="_blank" href="http://nci.org.au">
+                <h4 class="muted">NCI</h4>
+                <img src="media/images/NCI_logo.png" class="thumbnail">
+            </a>
+        </div>
+    </div>
+</div>

--- a/2020-F2F.md
+++ b/2020-F2F.md
@@ -1,0 +1,26 @@
+---
+layout: default
+title: 9th ESGF Face-to-Face Conference
+---
+
+## 9th ESGF Face-to-Face Conference
+
+The 9th ESGF Face-to-Face Conference, co-organized by DKRZ and Météo-France, will be held on March 23rd-25th 2020 at the “Centre International de Conférences” on Météo-France campus in Toulouse, France.
+
+The workshop aims to bring together leading researchers and practitioners in the field of climate data research infrastructures. In addition to the presentation of the status and the CMIP6 integration, near term implementations and the future architecture of ESGF (Earth System Grid Federation) will be discussed and coordinated. Central part of the conference is the exchange between ESGF developers in the working teams and the infrastructure users.
+
+Topics relevant to the workshop include, but are not limited to:
+
+- ESGF status report
+- User experiences
+- Technology developments
+- Implementation roadmap
+- ESGF future architecture
+
+Details on agenda, abstract submission and conference registration are provided soon.
+
+This workshop is co-organised by the EU H2020 IS-ENES3 project and the Lawrence Livermore National Laboratory (LLNL).
+
+ESGF participants are invited to attend the IS-ENES3 General Assembly, which will take place from Wednesday, March 25th to Friday, March 27th at the Centre International de Conférence, Toulouse.
+
+Contact: Michael Lautenschlager, ESGF Executive Committee Chair (lautenschlager[at]dkrz.de). 

--- a/index.html
+++ b/index.html
@@ -63,6 +63,46 @@ title: ESGF Home Page
 
 <div class="hero-unit announcement">
     <center>
+    <h3><a href="{{site.url}}/2019-Future-Arch-Workshop.html">
+        ESGF Future Architecture Workshop<br>
+        November 5-7, 2019 in Abingdon
+    </a></h3>
+    </center>
+</div>
+
+
+<div class="hero-unit announcement">
+    <center>
+    <h3><a href="{{site.url}}/2020-F2F.html">
+        9th ESGF Face-to-Face Conference<br>
+        March 23-25, 2020 at the Centre International de Conférence, Toulouse
+    </a></h3>
+    </center>
+</div>
+
+
+<div class="hero-unit announcement">
+    <center>
+    <h3><a href="https://is.enes.org/events/workshops/5th-workshop-on-coupling-technologies-for-earth-system-models">
+        5th Workshop on Coupling Technologies for Earth System Models<br>
+        March 23-25, 2020 at the Centre International de Conférence, Toulouse
+    </a></h3>
+    </center>
+</div>
+
+
+<div class="hero-unit announcement">
+    <center>
+    <h3><a href="https://is.enes.org/events/workshops/is-enes3-first-general-assembly">
+        IS-ENES3 First General Assembly<br>
+        March 25-27, 2020 at the Centre International de Conférence, Toulouse
+    </a></h3>
+    </center>
+</div>
+
+
+<div class="hero-unit announcement">
+    <center>
     <h3><a href="{{site.url}}/esgf-compute-announcement.html">
         ESGF Compute Release Announcement</a></h3>
     </center>


### PR DESCRIPTION
Adds announcements for future ESGF events to the front page.  Also adds pages for the [ESGF Future Architecture Workshop](https://is.enes.org/events/workshops/esgf-future-architecture-workshop) and [9th ESGF Face-to-Face](https://is.enes.org/events/workshops/9th-esgf-face-to-face-conference); their info was copied directly from the pages on https://is.enes.org/events/workshops.