### PR TITLE
Fix Stephan Kindermann's affiliation

### DIFF
--- a/2020-F2F.md
+++ b/2020-F2F.md
@@ -66,7 +66,7 @@ V. Balaji | Princeton University
 Sasha Ames | Lawrence Livermore National Laboratory (LLNL)
 Laura Carriere | National Aeronautics and Space Administration (NASA)
 Philip Kershaw | Centre for Environmental Data Analysis (CEDA)
-Stephan Kindermann | University of Linz
+Stephan Kindermann | German Climate Computing Center (DKRZ)
 Tom Landry | Computer Research Institute of Montreal (CRIM)
 Guillaume Levavasseur | Institut Pierre Simon Laplace (IPSL)
  | 


### PR DESCRIPTION
Stephan Kindermann is affiliated with German Climate Computing Center (DKRZ)